### PR TITLE
Fixed urls.py to support django 1.10+ (patterns deprecated in 1.8)

### DIFF
--- a/podcast/urls.py
+++ b/podcast/urls.py
@@ -1,25 +1,26 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
+from .views import *
 
 
-urlpatterns = patterns('podcast.views',
+urlpatterns = [
     # Show list of all shows
-    url(r'^$', view='show_list', name='podcast_shows'),
+    url(r'^$', show_list, name='podcast_shows'),
 
     # Episode list of one show
-    url(r'^(?P<slug>[-\w]+)/$', view='episode_list', name='podcast_episodes'),
+    url(r'^(?P<slug>[-\w]+)/$', episode_list, name='podcast_episodes'),
 
     # Episode list feed by show (RSS 2.0 and iTunes)
-    url(r'^(?P<slug>[-\w]+)/feed/$', view='show_list_feed', name='podcast_feed'),
+    url(r'^(?P<slug>[-\w]+)/feed/$', show_list_feed, name='podcast_feed'),
 
     # Episode list feed by show (Atom)
-    url(r'^(?P<slug>[-\w]+)/atom/$', view='show_list_atom', name='podcast_atom'),
+    url(r'^(?P<slug>[-\w]+)/atom/$', show_list_atom, name='podcast_atom'),
 
     # Episode list feed by show (Media RSS)
-    url(r'^(?P<slug>[-\w]+)/media/$', view='show_list_media', name='podcast_media'),
+    url(r'^(?P<slug>[-\w]+)/media/$', show_list_media, name='podcast_media'),
 
     # Episode sitemap list of one show
-    url(r'^(?P<slug>[-\w]+)/sitemap.xml$', view='episode_sitemap', name='podcast_sitemap'),
+    url(r'^(?P<slug>[-\w]+)/sitemap.xml$', episode_sitemap, name='podcast_sitemap'),
 
     # Episode detail of one show
-    url(r'^(?P<show_slug>[-\w]+)/(?P<episode_slug>[-\w]+)/$', view='episode_detail', name='podcast_episode'),
-)
+    url(r'^(?P<show_slug>[-\w]+)/(?P<episode_slug>[-\w]+)/$', episode_detail, name='podcast_episode'),
+]


### PR DESCRIPTION
In 1.8, django.conf.urls.patterns() was deprecated. In 1.10 it was removed.